### PR TITLE
feat: Add 'type' field to MCPServerConfig for explicit client selection

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,9 +4,20 @@ import (
 	"github.com/spf13/viper"
 )
 
-// MCPServerConfig holds the configuration for a single MCP server, including custom headers.
+// MCPClientType defines the type of MCP client to use for a server.
+type MCPClientType string
+
+const (
+	// ClientTypeSSE uses the NewSSEMCPClient.
+	ClientTypeSSE MCPClientType = "sse"
+	// ClientTypeStreamableHTTP uses the NewStreamableHttpClient.
+	ClientTypeStreamableHTTP MCPClientType = "streamable_http"
+)
+
+// MCPServerConfig holds the configuration for a single MCP server, including custom headers and client type.
 type MCPServerConfig struct {
 	URL     string            `mapstructure:"url"`
+	Type    MCPClientType     `mapstructure:"type"` // "sse" or "streamable_http"
 	Headers map[string]string `mapstructure:"headers"`
 }
 


### PR DESCRIPTION
Introduces an `MCPClientType` enum (`sse`, `streamable_http`) and a corresponding `Type` field in the `MCPServerConfig` struct within `internal/config/config.go`.

The agent's MCP client initialization logic in `internal/agent/agent.go` has been updated to use this `Type` field instead of URL prefix matching to determine whether to use `NewSSEMCPClient` or `NewStreamableHttpClient`.

This change allows for more explicit and flexible configuration of MCP server connections.

User Action Required:
Update `config.yaml` to include the `type` field for each entry in `mcp_servers`. Example:
```yaml
mcp_servers:
  - url: "http://mcp-server1.example.com/mcp"
    type: "sse" # or "streamable_http"
    headers:
      Authorization: "Bearer token123"
```
If `type` is missing or invalid, the server config will be skipped with a warning.